### PR TITLE
Update FieldGenerator.php

### DIFF
--- a/src/OscarAFDev/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/OscarAFDev/MigrationsGenerator/Generators/FieldGenerator.php
@@ -73,8 +73,8 @@ class FieldGenerator {
 	protected function setEnum(array $fields, $table)
 	{
 		foreach ($this->getEnum($table) as $column) {
-			$fields[$column->column_name]['type'] = 'enum';
-			$fields[$column->column_name]['args'] = str_replace('enum(', 'array(', $column->column_type);
+			$fields[$column->COLUMN_NAME]['type'] = 'enum';
+			$fields[$column->COLUMN_NAME]['args'] = str_replace('enum(', 'array(', $column->COLUMN_TYPE);
 		}
 		return $fields;
 	}


### PR DESCRIPTION
When retrieving information about the columns assigned to a table, the resulting column names should be in upper case, not lower. It was throwing an exception with the lower case ones. I believe this only affected columns with type `ENUM`