### PR TITLE
More forgiving ignore option

### DIFF
--- a/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
@@ -396,7 +396,7 @@ class MigrateGenerateCommand extends GeneratorCommand {
 		$excludes = ['migrations'];
 		$ignore = $this->option('ignore');
 		if ( ! empty($ignore)) {
-			return array_merge($excludes, explode(',', $ignore));
+			return array_merge($excludes, preg_split('/[,\s]+/', ignore));
 		}
 
 		return $excludes;


### PR DESCRIPTION
Thanks for this amazing package :rocket:
I ran into some headache when I using `--ignore="table1, table2, ...` because of the exploding does not allow whitespace. How about changing that to a more forgiving `preg_split`?

Example:
```
$list = "a, b,c d";

preg_split('/[,\s]+/', $list);

```
Giving
```
[
     "a",
     "b",
     "c",
     "d",
   ]
```
This might be implemented in other places as well.