### PR TITLE
Update MigrateGenerateCommand.php

### DIFF
--- a/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/OscarAFDev/MigrationsGenerator/MigrateGenerateCommand.php
@@ -396,7 +396,7 @@ class MigrateGenerateCommand extends GeneratorCommand {
 		$excludes = ['migrations'];
 		$ignore = $this->option('ignore');
 		if ( ! empty($ignore)) {
-			return array_merge($excludes, preg_split('/[,\s]+/', ignore));
+			return array_merge($excludes, preg_split('/[,\s]+/', $ignore));
 		}
 
 		return $excludes;


### PR DESCRIPTION
"--ignore" option doesn't work (ErrorException) because "$" is missed
![laravel-migrations-genetor-error](https://user-images.githubusercontent.com/31555614/80380180-7efe6400-889f-11ea-9a35-342bdd165ac2.PNG)
